### PR TITLE
add support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ The official Python toolbox for parsing the PicoScenes **.csi** files.
 - High scalability
 - The official toolbox for parsing .csi
 
+## Preparation steps on Windows 10 or 11
 
+1. Install [TDM-GCC-64](https://jmeubank.github.io/tdm-gcc/) (choose MinGW-w64 based version, version 10.3+);
+2. Set Compiler to MinGW64 using [mingw64ccompiler](https://github.com/imba-tjd/mingw64ccompiler)
+```bash
+pip install git+https://github.com/imba-tjd/mingw64ccompiler
+python -m mingw64ccompiler install_specs  # Run once
+python -m mingw64ccompiler install        # Works with venv
+```
 
 ## Install
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 i = 0  # stands for the first frame of csi frames
 
-frames = Picoscenes("rx4.csi")
+frames = Picoscenes("rx_by_usrpN210.csi")
 numTones = frames.raw[i].get("CSI").get("numTones")
 SubcarrierIndex = np.array(frames.raw[i].get("CSI").get("SubcarrierIndex"))
 Mag = np.array(frames.raw[i].get("CSI").get("Mag"))[:numTones]

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,15 @@ EXTENSIONS = []
 
 class Build(build_ext):
     def build_extensions(self):
-        if self.compiler.compiler_type in ['unix', 'mingw32']:
-            for e in self.extensions:
-                if e.name == "picoscenes":
-                    e.extra_compile_args = ['-std=c++2a', '-Wno-attributes',
-                                            '-O3']
         if self.compiler.compiler_type in ["msvc"]:
             for e in self.extensions:
                 if e.name == "picoscenes":
                     e.extra_compile_args = ['/std:c++latest']
+        else:
+            for e in self.extensions:
+                if e.name == "picoscenes":
+                    e.extra_compile_args = ['-std=c++2a', '-Wno-attributes',
+                                            '-O3']
         super(Build, self).build_extensions()
 
 


### PR DESCRIPTION
The RXS parsing lib is supported by Windows and tested according to [PicoScenes documentation](https://ps.zpj.io/matlab.html#preparation-steps-on-windows-10-or-11). Hence, to better support researches on Windows platform, the following change could be made.

1. Add a guide to teach user install the compiler used in the Pico doc, which is [TDM-GCC-64](https://jmeubank.github.io/tdm-gcc/).
2. Using a Python package, [mingw64ccompiler](https://github.com/imba-tjd/mingw64ccompiler), to force setuptool using MinGW64 instead of the 32 bit version. (32 bit version results in errors).
3. Modify setup.py to better add args of compiler

All above changes are tested on my computer, including using two different versions of RXS lib (in this repo, and in the gitlab repo). A .pyd file is successfully generated and can be imported on Windows platform (attatched for further test).

[picoscenes.cp39-win_amd64.zip](https://github.com/Herrtian/PicoscenesToolbox/files/11851059/picoscenes.cp39-win_amd64.zip)
