### PR TITLE
Delete unnecessary print

### DIFF
--- a/picoscenes.pyx
+++ b/picoscenes.pyx
@@ -349,8 +349,6 @@ cdef class Picoscenes:
         free(buf)
         fclose(f)
         self.count = count
-        if self.if_report:
-            printf("%d packets parsed\n", count)
 
     cpdef pmsg(self, unsigned char *data):
         # This method hasn't been ready


### PR DESCRIPTION
![image](https://github.com/Herrtian/PicoscenesToolbox/assets/125537183/f285cca4-a22b-447a-b75a-e823c727ebee)

I have written a script to convert raw files to numpy. I find the print really annoying when I use a progress bar. Maybe it is better to delete unnecessary print. Or return the number of the packet instead of printing it.